### PR TITLE
v2: update to use reflection over service names

### DIFF
--- a/di/container_test.go
+++ b/di/container_test.go
@@ -7,106 +7,64 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestContainer_GetNonExistantService_Panics(t *testing.T) {
-	ctn := NewContainer()
-
-	defer func() {
-		if r := recover(); r == nil {
-			t.Errorf("Expected panic")
+func TestContainer_GetService(t *testing.T) {
+	t.Run("Where Service Exists", func(t *testing.T) {
+		ctor1 := func() *testDependency {
+			return &testDependency{}
 		}
-	}()
+		ctor2 := func() *testDependency2 {
+			return &testDependency2{}
+		}
 
-	_ = ctn.GetService("myService")
+		ctn := NewContainer()
+		ctn.AddService(ctor1)
+		ctn.AddService(ctor2).SetName("MyService")
+
+		v, ok := ctn.GetService("MyService").(*testDependency2)
+		assert.NotNil(t, v)
+		assert.True(t, ok)
+	})
+
+	t.Run("Where Build Fails", func(t *testing.T) {
+		ctor := func() (*testDependency, error) {
+			return nil, assert.AnError
+		}
+
+		ctn := NewContainer()
+		ctn.AddService(ctor).SetName("MyService")
+
+		defer func() {
+			err := recover().(error)
+			assert.NotNil(t, err)
+			assert.Contains(t, err.Error(), assert.AnError.Error())
+		}()
+
+		// Should panic
+		_ = ctn.GetService("MyService")
+	})
+
+	t.Run("Where The Service Does Not Exist", func(t *testing.T) {
+		ctn := NewContainer()
+
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("Expected panic")
+			}
+		}()
+
+		_ = ctn.GetService("MyService")
+	})
 }
 
 func TestContainer_AddService(t *testing.T) {
-	builder := func(ctn *Container) interface{} {
+	ctor := func() interface{} {
 		return nil
 	}
-	name := "myService"
 
 	ctn := NewContainer()
-	sb := ctn.AddService(name, builder)
-	assert.NotNil(t, sb)
-
-	srv, ok := ctn.srvConf[name]
-	assert.True(t, ok)
-	assert.False(t, srv.Singleton)
-}
-
-func TestContainer_AddSingleton(t *testing.T) {
-	builder := func(ctn *Container) interface{} {
-		return nil
-	}
-	name := "myService"
-
-	ctn := NewContainer()
-	sb := ctn.AddSingleton(name, builder)
-	assert.NotNil(t, sb)
-
-	srv, ok := ctn.srvConf[name]
-	assert.True(t, ok)
-	assert.True(t, srv.Singleton)
-}
-
-func TestContainer_SingletonNotRecreated(t *testing.T) {
-	ctn := NewContainer()
-
-	ctn.srvConf["test"] = &ServiceConfig{
-		Singleton: true,
-		Build: func(ctn *Container) interface{} {
-			srvValue := "My super cool service"
-			return &srvValue
-		},
-	}
-
-	srv := ctn.GetService("test")
-	srv2 := ctn.GetService("test")
-
-	if srv != srv2 {
-		t.Error("Expected the services to be equal")
-	}
-}
-
-func TestContainer_TransientIsRecreated(t *testing.T) {
-	ctn := NewContainer()
-
-	ctn.srvConf["test"] = &ServiceConfig{
-		Singleton: false,
-		Build: func(ctn *Container) interface{} {
-			srvValue := "My super cool service"
-			return &srvValue
-		},
-	}
-
-	srv := ctn.GetService("test")
-	srv2 := ctn.GetService("test")
-
-	if srv == srv2 {
-		t.Error("Expected the services to not be equal")
-	}
-}
-
-func TestContainer_WithDependentService(t *testing.T) {
-	ctn := NewContainer()
-
-	ctn.srvConf["text1"] = &ServiceConfig{
-		Singleton: false,
-		Build: func(ctn *Container) interface{} {
-			return "World"
-		},
-	}
-
-	ctn.srvConf["text2"] = &ServiceConfig{
-		Singleton: false,
-		Build: func(ctn *Container) interface{} {
-			w := ctn.GetService("text1").(string)
-			return "Hello " + w
-		},
-	}
-
-	t2 := ctn.GetService("text2")
-	assert.Equal(t, "Hello World", t2)
+	s := ctn.AddService(ctor)
+	assert.NotNil(t, s)
+	assert.Same(t, s, ctn.services[0])
 }
 
 func TestContainer_Clean(t *testing.T) {
@@ -115,17 +73,20 @@ func TestContainer_Clean(t *testing.T) {
 	testValue := "My String"
 
 	ctn := NewContainer()
-	ctn.AddSingleton("MyService", func(ctn *Container) interface{} {
+	ctn.AddService(func() interface{} {
 		return testValue
-	}).Dispose(func(ctx context.Context, i interface{}) {
-		assert.Equal(t, testCtx, ctx)
-		assert.Equal(t, testValue, i)
+	}).
+		AsSingleton().
+		SetDispose(func(ctx context.Context, i interface{}) {
+			assert.Equal(t, testCtx, ctx)
+			assert.Equal(t, testValue, i)
 
-		// Proves that the dispose has only been called once.
-		assert.False(t, hasBeenDisposed)
+			// Proves that the dispose has only been called once.
+			assert.False(t, hasBeenDisposed)
 
-		hasBeenDisposed = true
-	})
+			hasBeenDisposed = true
+		}).
+		SetName("MyService")
 
 	// Builds the service
 	_ = ctn.GetService("MyService")
@@ -133,14 +94,5 @@ func TestContainer_Clean(t *testing.T) {
 	ctn.Clean(testCtx)
 
 	assert.True(t, hasBeenDisposed)
-	assert.Nil(t, ctn.srvs["MyService"])
-}
-
-func TestServiceBuilder_Dispose(t *testing.T) {
-	s := &ServiceConfig{Dispose: nil}
-	b := &ServiceBuilder{s: s}
-
-	r := b.Dispose(func(ctx context.Context, i interface{}) {})
-	assert.Equal(t, b, r)
-	assert.NotNil(t, s.Dispose)
+	assert.Nil(t, ctn.services[0].impl)
 }

--- a/di/service.go
+++ b/di/service.go
@@ -1,0 +1,188 @@
+package di
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sync"
+)
+
+// ServiceLifetime is a type used to define a service's lifetime.
+type ServiceLifetime uint
+
+const (
+	// LifetimeSingleton is used to define a Service as a singleton.
+	// Which means only a single instance of the Service will be built,
+	// then shared across other services.
+	LifetimeSingleton ServiceLifetime = iota
+
+	// LifetimeTransient is used to define a Service as transient. Which
+	// means a new instance will be instantiated each time the service is resolved.
+	LifetimeTransient
+)
+
+// DisposeFunc is a function used to clean and dispose a singleton service.
+// The argument, i, is the instance of the service.
+type DisposeFunc func(ctx context.Context, i interface{})
+
+// Service represents a service within the DI Container. It contains
+// information on the type, lifetime and name of the service, as well
+// as, how to build it.
+type Service struct {
+	name     string
+	typ      reflect.Type
+	lifetime ServiceLifetime
+	ctor     interface{}
+	mu       sync.Mutex
+	impl     interface{}
+	dipsose  DisposeFunc
+}
+
+// NewService is used to create a new instance of Service. The ctor argument
+// should be the constructor function, which is used to build the service.
+//
+// A constructor function can contain an range of arguments, however, either
+// return an interface, or an interface and error: func() MyService or
+// func() (MyService, error).
+func NewService(ctor interface{}) *Service {
+	t := reflect.TypeOf(ctor)
+	if t.Kind() != reflect.Func {
+		panic(fmt.Errorf("service: %s is not a func", t.Name()))
+	}
+
+	switch t.NumOut() {
+	case 0:
+		panic(fmt.Errorf("service: %s should return a value", t.Name()))
+	case 1:
+		if isTypeError(t.Out(0)) {
+			panic(fmt.Errorf("service: %s should return a non-error value", t.Name()))
+		}
+	case 2:
+		if isTypeError(t.Out(0)) {
+			panic(fmt.Errorf("service: %s should return (interface{}, error)", t.Name()))
+		}
+
+		if !isTypeError(t.Out(1)) {
+			panic(fmt.Errorf("service: %s should return (interface{}, error)", t.Name()))
+		}
+	default:
+		panic(fmt.Errorf("service: %s can not contain more than 2 return values", t.Name()))
+	}
+
+	st := t.Out(0)
+	name := st.String()
+	if st.Kind() == reflect.Ptr {
+		name = st.Elem().String()
+	}
+
+	return &Service{
+		name:     name,
+		typ:      st,
+		lifetime: LifetimeTransient,
+		ctor:     ctor,
+		mu:       sync.Mutex{},
+	}
+}
+
+// This is used to determine whether a Type is an error or not.
+func isTypeError(t reflect.Type) bool {
+	err := reflect.TypeOf((*error)(nil)).Elem()
+	return t.Implements(err)
+}
+
+// SetName is used to set the name of the Service. Note that
+// this is can not be referred to in depedency injection, and
+// only when resolving a service through the Container.
+//
+// If name is empty, the name will not be updated and will remain
+// the name of the service interface.
+func (s *Service) SetName(name string) *Service {
+	if name != "" {
+		s.name = name
+	}
+
+	return s
+}
+
+// Name returns the name of the service. If this has not been manually
+// configured, the name of the service type will be returned.
+func (s *Service) Name() string {
+	return s.name
+}
+
+// SetDispose is used to configure a clean up/disposal function for a
+// service. This can be used to set a dispose function for a service with
+// any lifetime, however, will only be used for Singleton service.
+//
+// This is not required but is helpful for releasing resources consumed
+// by the service.
+func (s *Service) SetDispose(f DisposeFunc) *Service {
+	s.dipsose = f
+
+	return s
+}
+
+// Dispose is used to clean up singleton resources.
+func (s *Service) Dispose(ctx context.Context) {
+	if s.dipsose != nil {
+		s.dipsose(ctx, s.impl)
+	}
+
+	s.impl = nil
+}
+
+// AsSingleton sets the lifetime of the service to Singleton.
+func (s *Service) AsSingleton() *Service {
+	s.lifetime = LifetimeSingleton
+
+	return s
+}
+
+// AsTransient sets the lifetime of the service to Transient.
+func (s *Service) AsTransient() *Service {
+	s.lifetime = LifetimeTransient
+
+	return s
+}
+
+func (s *Service) build(ctn *Container) (interface{}, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// If the service is a singleton and already built, used the
+	// build instance instead of creating another.
+	if s.impl != nil && s.lifetime == LifetimeSingleton {
+		return s.impl, nil
+	}
+
+	f := reflect.ValueOf(s.ctor)
+	numIn := f.Type().NumIn()
+	args := make([]reflect.Value, numIn)
+
+	for i := 0; i < numIn; i++ {
+		arg := f.Type().In(i)
+		d, err := ctn.getService(arg)
+		if err != nil {
+			return nil, err
+		}
+
+		args[i] = reflect.ValueOf(d)
+	}
+
+	out := f.Call(args)
+	if len(out) == 2 {
+		err := out[1].Interface()
+		if err != nil {
+			return nil, err.(error)
+		}
+	}
+
+	impl := out[0].Interface()
+
+	// If the sevrice is a singleton, store the built instance in memory.
+	if s.lifetime == LifetimeSingleton {
+		s.impl = impl
+	}
+
+	return impl, nil
+}

--- a/di/service_test.go
+++ b/di/service_test.go
@@ -1,0 +1,334 @@
+package di
+
+import (
+	"context"
+	"math/rand"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type TestService interface{}
+
+type testService struct {
+	dep *testDependency
+	x   int
+}
+
+type testDependency struct{}
+
+// With no imagination, this is just another test dependency.
+type testDependency2 struct{}
+
+func TestNewService_GivenValidCtorFunc_ReturnsService(t *testing.T) {
+	t.Run("Where Return Value Is Interface", func(t *testing.T) {
+		f := func() TestService {
+			return &testService{}
+		}
+
+		s := NewService(f)
+		assert.Equal(t, "di.TestService", s.name)
+		assert.Equal(t, LifetimeTransient, s.lifetime)
+
+		_, ok := reflect.New(s.typ).Interface().(*TestService)
+		assert.True(t, ok)
+	})
+
+	t.Run("Where Return Value Is Ptr", func(t *testing.T) {
+		f := func() *testService {
+			return &testService{}
+		}
+
+		s := NewService(f)
+		assert.Equal(t, "di.testService", s.name)
+		assert.Equal(t, LifetimeTransient, s.lifetime)
+
+		_, ok := reflect.New(s.typ).Elem().Interface().(*testService)
+		assert.True(t, ok)
+	})
+}
+
+func TestNewService_GivenInvalidCtorFunc_Panics(t *testing.T) {
+	assert.Panics(t, func() {
+		// f does is not valid because a func cannot only return an error.
+		f := func() error {
+			return nil
+		}
+
+		_ = NewService(f)
+	})
+
+	assert.Panics(t, func() {
+		// f does is not valid because a func should return
+		// an error value last.
+		f := func() (error, interface{}) {
+			return nil, nil
+		}
+
+		_ = NewService(f)
+	})
+
+	assert.Panics(t, func() {
+		// f does is not valid because a func should only
+		// return a single interface value.
+		f := func() (interface{}, interface{}) {
+			return nil, nil
+		}
+
+		_ = NewService(f)
+	})
+
+	assert.Panics(t, func() {
+		// f does is not valid because a func should only
+		// return between 1 and 2 values.
+		f := func() (interface{}, interface{}, error) {
+			return nil, nil, nil
+		}
+
+		_ = NewService(f)
+	})
+
+	assert.Panics(t, func() {
+		// f does is not valid because a func should return a value.
+		f := func() {}
+
+		_ = NewService(f)
+	})
+
+	assert.Panics(t, func() {
+		// f is not a func value.
+		f := "this is not a func"
+
+		_ = NewService(f)
+	})
+}
+
+func TestService_SetName(t *testing.T) {
+	t.Run("Given Valid Name", func(t *testing.T) {
+		s := &Service{}
+		name := "MyService"
+		s.SetName(name)
+		assert.Equal(t, name, s.name)
+	})
+
+	t.Run("Given Empty Name", func(t *testing.T) {
+		name := "MyService"
+		s := &Service{name: name}
+
+		// Does not set name.
+		s.SetName("")
+		assert.Equal(t, name, s.name)
+	})
+}
+
+func TestService_Name(t *testing.T) {
+	name := "MyService"
+	s := &Service{name: name}
+	assert.Equal(t, name, s.Name())
+}
+
+func TestService_SetDispose(t *testing.T) {
+	s := &Service{}
+	s.SetDispose(func(ctx context.Context, i interface{}) {
+		// empty dispose func
+	})
+
+	assert.NotNil(t, s.dipsose)
+}
+
+func TestService_Dispose(t *testing.T) {
+	t.Run("Where Dispose Has Been Set", func(t *testing.T) {
+		called := false
+		instance := "some service"
+		s := &Service{impl: instance}
+		s.SetDispose(func(ctx context.Context, i interface{}) {
+			assert.Equal(t, instance, i)
+			called = true
+		})
+
+		s.Dispose(context.Background())
+		assert.True(t, called)
+		assert.Nil(t, s.impl)
+	})
+
+	t.Run("Where Dispose Has Not Been Set", func(t *testing.T) {
+		s := &Service{}
+
+		s.Dispose(context.Background())
+		assert.Nil(t, s.impl)
+	})
+}
+
+func TestService_AsSingleton(t *testing.T) {
+	s := &Service{lifetime: LifetimeTransient}
+	s.AsSingleton()
+
+	assert.Equal(t, LifetimeSingleton, s.lifetime)
+}
+
+func TestService_AsTransient(t *testing.T) {
+	s := &Service{lifetime: LifetimeSingleton}
+	s.AsTransient()
+
+	assert.Equal(t, LifetimeTransient, s.lifetime)
+}
+
+func TestService_Build(t *testing.T) {
+	t.Run("Given Transient Service", func(t *testing.T) {
+		ctn := NewContainer()
+		ctor := func() (*testService, error) {
+			return &testService{
+				x: rand.Int(),
+			}, nil
+		}
+		s := &Service{
+			ctor:     ctor,
+			typ:      reflect.TypeOf(&testService{}),
+			lifetime: LifetimeTransient,
+		}
+
+		v1, err := s.build(ctn)
+		assert.NotNil(t, v1)
+		assert.Nil(t, err)
+
+		v2, err := s.build(ctn)
+		assert.NotNil(t, v2)
+		assert.Nil(t, err)
+
+		// Assert that the two builds are different
+		// as the service is transient.
+		assert.NotSame(t, v1, v2)
+	})
+
+	t.Run("Given Singleton Service", func(t *testing.T) {
+		ctn := NewContainer()
+		ctor := func() (*testService, error) {
+			return &testService{
+				x: rand.Int(),
+			}, nil
+		}
+		s := &Service{
+			ctor:     ctor,
+			typ:      reflect.TypeOf(&testService{}),
+			lifetime: LifetimeSingleton,
+		}
+
+		v1, err := s.build(ctn)
+		assert.NotNil(t, v1)
+		assert.Nil(t, err)
+
+		v2, err := s.build(ctn)
+		assert.NotNil(t, v2)
+		assert.Nil(t, err)
+
+		// Assert that the two builds are the same
+		// as the service is a singleton.
+		assert.Same(t, v1, v2)
+	})
+
+	t.Run("Where Ctor Returns Error", func(t *testing.T) {
+		ctn := NewContainer()
+		ctor := func() (*testService, error) {
+			return nil, assert.AnError
+		}
+		s := &Service{
+			ctor: ctor,
+			typ:  reflect.TypeOf(&testService{}),
+		}
+
+		v1, err := s.build(ctn)
+		assert.Nil(t, v1)
+		assert.Equal(t, assert.AnError, err)
+	})
+
+	t.Run("Where Service Has Dependency", func(t *testing.T) {
+		ctn := NewContainer()
+		ctn.services = []*Service{
+			{
+				name:     "di.testDependency",
+				typ:      reflect.TypeOf(&testDependency{}),
+				lifetime: LifetimeTransient,
+				ctor: func() *testDependency {
+					return &testDependency{}
+				},
+			},
+		}
+		ctor := func(d *testDependency) (*testService, error) {
+			return &testService{
+				dep: d,
+				x:   rand.Int(),
+			}, nil
+		}
+		s := &Service{
+			ctor:     ctor,
+			typ:      reflect.TypeOf(&testService{}),
+			lifetime: LifetimeSingleton,
+		}
+
+		v, err := s.build(ctn)
+		assert.NotNil(t, v)
+		assert.Nil(t, err)
+
+		ts := v.(*testService)
+		assert.NotNil(t, ts.dep)
+	})
+
+	t.Run("Where Service Cannot Find Dependency", func(t *testing.T) {
+		ctn := NewContainer()
+		ctn.services = []*Service{
+			{
+				name:     "di.testDependency",
+				typ:      reflect.TypeOf(&testDependency{}),
+				lifetime: LifetimeTransient,
+				ctor: func() *testDependency {
+					return &testDependency{}
+				},
+			},
+		}
+		ctor := func(d *testDependency, d2 *testDependency2) (*testService, error) {
+			return &testService{
+				dep: d,
+				x:   rand.Int(),
+			}, nil
+		}
+		s := &Service{
+			ctor:     ctor,
+			typ:      reflect.TypeOf(&testService{}),
+			lifetime: LifetimeSingleton,
+		}
+
+		v, err := s.build(ctn)
+		assert.Nil(t, v)
+		assert.NotNil(t, err)
+	})
+
+	t.Run("Where Service Dependency Failed To Build", func(t *testing.T) {
+		ctn := NewContainer()
+		ctn.services = []*Service{
+			{
+				name:     "di.testDependency",
+				typ:      reflect.TypeOf(&testDependency{}),
+				lifetime: LifetimeTransient,
+				ctor: func() (*testDependency, error) {
+					return nil, assert.AnError
+				},
+			},
+		}
+		ctor := func(d *testDependency, d2 *testDependency2) (*testService, error) {
+			return &testService{
+				dep: d,
+				x:   rand.Int(),
+			}, nil
+		}
+		s := &Service{
+			ctor:     ctor,
+			typ:      reflect.TypeOf(&testService{}),
+			lifetime: LifetimeSingleton,
+		}
+
+		v, err := s.build(ctn)
+		assert.Nil(t, v)
+		assert.Contains(t, err.Error(), assert.AnError.Error())
+	})
+}


### PR DESCRIPTION
This change is to help resolve an issue where in larger projects defining lots of services gets bulky. This is due to having to manually resolve each dependency in the `BuildFunc`, then manually instantiating a new instance of the service. 

The new method of adding a service to the container is to define one by constructor.

```go
type MyService struct{}

func NewService() *MyService {
  return &MyService{}
}

ctn := di.NewContainer()

// Registers a new service as *MyService
ctn.AddService(NewService).SetName("MyService")

s := ctn.GetService("MyService).(*MyService)
// Do something here...
```

This is someone experimental and should help things move forward while waiting for Go 1.18 and generics.